### PR TITLE
DTSGen.py: Use a longer RNG seed for XiangShan NEMU board

### DIFF
--- a/dts/DTSGen.py
+++ b/dts/DTSGen.py
@@ -16,7 +16,7 @@ class DTSGen:
                  memories: list = [(0x80000000, 8*1024*1024*1024)], # [(start, size)], default 8 GB at 2 GB
                  reserved_memories: list = [], # [(start, size)]
                  bootargs: str = "console=hvc0 earlycon=sbi rdinit=/sbin/init",
-                 rng_seed: bytes = b"NEMU_BOARD",
+                 rng_seed: bytes = b"XIANGSHAN_NEMU_BOARD_RANDOM_SEED",
                  uartlite_addr: int = 0x40600000,
                  nemu_sdhci_addr: int = None):
         self.isa_extensions = isa_extensions


### PR DESCRIPTION
Currently, the RNG seed used in the XiangShan NEMU board is "NEMU_BOARD", which is only 10 bytes long. This short seed may not provide sufficient entropy for kernel crng initialization, leading to user applications that rely on /dev/urandom to block during startup.

To address this issue, we propose to extend the RNG seed to "XIANGSHAN_NEMU_BOARD_RANDOM_SEED", which is 32 bytes long. This longer seed will provide better entropy, reducing the likelihood of blocking during application startup.